### PR TITLE
Add velocity

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -30,7 +30,9 @@
 
 			// Initialize our shape
 			model = new SimpleMesh({
-				context : ctx
+				context : ctx,
+				// Uncomment below to demo velocity
+				// velocity : { x: 0.5, y: -1 }
 			});
 
 			// Load a basic model

--- a/simple-mesh.js
+++ b/simple-mesh.js
@@ -1,11 +1,11 @@
 /*!
  * SimpleMesh
  * Copyright (c) 2013 Eric Johnson
- * Version 0.5 
+ * Version 0.5
  * Licensed under the MIT license
  * http://ericjohnson.me
  */
- 
+
 /* *
 * SimpleMesh namespace + constructor
 */
@@ -23,6 +23,7 @@ var SimpleMesh = function( opts ) {
 		fog : false,
 		origin : { x:0, y:0, z:0 },
 		theta : { x:0, y:0, z:0 }, // Rotation angles in +/- degrees
+    velocity: { x:0, y:0 }, // Linear velocity
 		vertices : {}, // Vertex container
 		vertexVisibility : false,
 		vertexStyle : {
@@ -113,7 +114,7 @@ var SimpleMesh = function( opts ) {
 				edge.a = this.vertices[ edge.a ];
 				edge.b = this.vertices[ edge.b ];
 
-				// 
+				//
 				this.edges[id] = new Edge(edge);
 			}
 
@@ -329,7 +330,7 @@ var Vertex = function ( opts ) {
 	if( opts.hasOwnProperty('y') == false ) throw 'Y is required';
 	if( opts.hasOwnProperty('z') == false ) throw 'Z is required';
 
-	// 
+	//
 	this.oX = opts.x;
 	this.oY = opts.y;
 	this.oZ = opts.z;
@@ -400,7 +401,7 @@ var Edge = function( opts ) {
 		str += Math.round( 100 + ( z * 0.5 ) ) + ', ';
 		str += Math.round( 100 + ( z * 0.5 ) ) + ', '
 		str += Math.round( 100 + ( z * 0.5 ) ) + ')';
-		
+
 		return str;
 	}
 

--- a/simple-mesh.js
+++ b/simple-mesh.js
@@ -243,6 +243,9 @@ var SimpleMesh = function( opts ) {
 		this.rotateY( this.theta.y );
 		this.rotateZ( this.theta.z );
 
+    // Update origin according to velocity
+    this.shiftOrigin( this.velocity );
+
 		// Translate
 		this.translate( this.origin );
 

--- a/simple-mesh.js
+++ b/simple-mesh.js
@@ -23,7 +23,7 @@ var SimpleMesh = function( opts ) {
 		fog : false,
 		origin : { x:0, y:0, z:0 },
 		theta : { x:0, y:0, z:0 }, // Rotation angles in +/- degrees
-    velocity: { x:0, y:0 }, // Linear velocity
+    velocity: { x:0, y:0, z:0 }, // Linear velocity
 		vertices : {}, // Vertex container
 		vertexVisibility : false,
 		vertexStyle : {
@@ -270,6 +270,12 @@ var SimpleMesh = function( opts ) {
 		// Reset
 		this.reset();
 	}
+
+  this.shiftOrigin = function( velocity ) {
+    this.origin.x += velocity.x;
+    this.origin.y += velocity.y;
+    this.origin.z += velocity.z;
+  }
 
 	this.rotateX = function( theta ) {
 		this.rotate( 'y', 'z', theta );


### PR DESCRIPTION
Added a simple velocity property to SimpleMesh object.
Added a method shiftOrigin() which updates origin according to velocity.
Added a call to shiftOrigin() from within SimpleMesh#draw(). 
Add commented out velocity demonstration lines 34-35 in basic.html.

Note:  It occurred to me that linear velocity would be about as common of a need for SimpleMesh objects as the rotational velocity provided in the theta property (it was for my asteroids game certainly), so here is a simple working implementation of that.
